### PR TITLE
add feature flag to enable malloc-usable-size used by optimize_filtes_for_memory feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ bzip2 = ["libspeedb-sys/bzip2"]
 rtti = ["libspeedb-sys/rtti"]
 multi-threaded-cf = []
 serde1 = ["serde"]
+malloc-usable-size = ["libspeedb-sys/malloc-usable-size"]
 
 [dependencies]
 libc = "0.2"

--- a/libspeedb-sys/Cargo.toml
+++ b/libspeedb-sys/Cargo.toml
@@ -31,6 +31,7 @@ zstd = ["zstd-sys"]
 zlib = ["libz-sys"]
 bzip2 = ["bzip2-sys"]
 rtti = []
+malloc-usable-size = []
 
 [dependencies]
 libc = "0.2"

--- a/libspeedb-sys/build.rs
+++ b/libspeedb-sys/build.rs
@@ -90,6 +90,11 @@ fn build_speedb() {
         config.define("USE_RTTI", Some("1"));
     }
 
+    #[cfg(feature = "malloc-usable-size")]
+    if target.contains("linux") {
+        config.define("ROCKSDB_MALLOC_USABLE_SIZE", Some("1"));
+    }
+
     config.include(".");
     config.define("NDEBUG", Some("1"));
 


### PR DESCRIPTION
it turns out, optimize_filters_for_memory feature is gated behind the malloc_usable_size flag being set: https://github.com/facebook/rocksdb/blob/main/include/rocksdb/table.h#L404-L405

https://github.com/facebook/rocksdb/blob/main/build_tools/build_detect_platform#L468

which we don't currently set so the feature is not doing anything right now.